### PR TITLE
Fetch submodules in CI and deploy workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          submodules: true
+          submodules: recursive
       - uses: actions/setup-node@v4
         with:
           node-version: 22

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          submodules: true
       - uses: actions/setup-node@v4
         with:
           node-version: 22

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,6 +19,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          submodules: true
       - uses: actions/setup-node@v4
         with:
           node-version: 22
@@ -32,6 +34,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          submodules: true
       - uses: actions/setup-node@v4
         with:
           node-version: 22

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          submodules: true
+          submodules: recursive
       - uses: actions/setup-node@v4
         with:
           node-version: 22
@@ -35,7 +35,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          submodules: true
+          submodules: recursive
       - uses: actions/setup-node@v4
         with:
           node-version: 22


### PR DESCRIPTION
## Summary
- Add `submodules: true` to all `actions/checkout@v4` steps in both CI and deploy workflows
- Shiro imports from sibling repos (fluffycoreutils, spirit) via Vite path aliases — without submodules checked out, builds can fail when these imports are resolved
- Aligns with foam's CI which already does this (b6e7c6f)

## Test plan
- [ ] CI workflow runs successfully on this PR
- [ ] Verify submodules are checked out during build step
- [ ] Confirm `npm run build` resolves fluffycoreutils and spirit imports

Generated with [Claude Code](https://claude.com/claude-code)